### PR TITLE
Fix problems when 0 is used as a key

### DIFF
--- a/weightedDict.py
+++ b/weightedDict.py
@@ -95,13 +95,13 @@ class WeightedDict:
 
     def keys(self):
         if not self.lt:
-            return [self.min_key] if self.min_key else []
+            return [self.min_key] if self.min_key is not None else []
         return self.lt.keys() + self.rt.keys()
 
     # Iterates over the keys in the keys' sorted order.
     def __iter__(self):
         if not self.lt:
-            if self.min_key:
+            if self.min_key is not None:
                 yield self.min_key
 
         else:
@@ -144,7 +144,7 @@ class WeightedDict:
 
         # Check to see if we're the top.
 
-        if not self.min_key:
+        if self.min_key is None:
             self.min_key, self.val = key, val
         # See if we're at the bottom.
         elif not self.lt:


### PR DESCRIPTION
Due to truth evaluations of `self.min_key`, 0 cannot currently be used as a key. If it is tried, `wdict.keys()` excludes 0 and `wdict.sample()` will never return 0. 

This fixes this by explicitly checking if `self.min_key` is/is not None. 